### PR TITLE
3 into 1

### DIFF
--- a/src/main/java/me/waterarchery/litsellchest/configuration/config/Config.java
+++ b/src/main/java/me/waterarchery/litsellchest/configuration/config/Config.java
@@ -30,6 +30,8 @@ public class Config extends ConfigManager {
                 )));
         addDefault(new ConfigPart("SoundsEnabled", true, Collections.emptyList()));
         addDefault(new ConfigPart("NotSellingNotification", true, Collections.emptyList()));
+        addDefault(new ConfigPart("PaymentFormatting", true, Collections.emptyList()));
+        addDefault(new ConfigPart("EcoPayRoundupDecimals", 2, Collections.emptyList()));
         addDefault(new ConfigPart("SoundsVolume", 5, Collections.emptyList()));
         addDefault(ConfigPart.of("Sounds", null, Arrays.asList("You can completely disable all sounds above.", "",
                         "Please use only the sounds that in here", "https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html")));

--- a/src/main/java/me/waterarchery/litsellchest/listeners/ShopMenuListener.java
+++ b/src/main/java/me/waterarchery/litsellchest/listeners/ShopMenuListener.java
@@ -19,8 +19,18 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.joml.RoundingMode;
+
+import java.math.BigDecimal;
 
 public class ShopMenuListener implements Listener {
+
+    private double round(double value) {
+        if (decimals < 0) {decimals = 2;}
+        BigDecimal bd = new BigDecimal(Double.toString(value));
+        bd = bd.setScale(decimals, RoundingMode.HALF_UP);
+        return bd.doubleValue();
+    }
 
     @EventHandler
     public void onShopMenuClick(InventoryClickEvent event) {
@@ -51,8 +61,11 @@ public class ShopMenuListener implements Listener {
                             player.getInventory().addItem(placeItem);
                             String msg = ConfigHandler.getInstance().getMessageLang("ChestBought")
                                     .replace("%money%", (balance - price) + "");
-                            String formatted = String.format("%,.2f", balance);
-                            msg.replace("%money%", formatted);
+                            if(LitSellChest.getInstance().getConfig().getBoolean("PaymentFormatting",false)) {
+                                BigDecimal bd = new BigDecimal(Double.toString(balance));
+                                bd = bd.setScale(LitSellChest.getInstance().getConfig().getInt("EcoPayRoundupDecimals",2), RoundingMode.HALF_UP);
+                                msg.replace("%money%",String.valueOf(bd.doubleValue()));
+                            }
                             libs.getMessageHandler().sendMessage(player, msg);
                             SoundManager.sendSound(player, "ChestReceive");
                         }

--- a/src/main/java/me/waterarchery/litsellchest/listeners/ShopMenuListener.java
+++ b/src/main/java/me/waterarchery/litsellchest/listeners/ShopMenuListener.java
@@ -49,9 +49,11 @@ public class ShopMenuListener implements Listener {
                             economy.withdrawPlayer(player, price);
                             ItemStack placeItem = sellChestType.toItemStack();
                             player.getInventory().addItem(placeItem);
-                            String mes = ConfigHandler.getInstance().getMessageLang("ChestBought")
+                            String msg = ConfigHandler.getInstance().getMessageLang("ChestBought")
                                     .replace("%money%", (balance - price) + "");
-                            libs.getMessageHandler().sendMessage(player, mes);
+                            String formatted = String.format("%,.2f", balance);
+                            msg.replace("%money%", formatted);
+                            libs.getMessageHandler().sendMessage(player, msg);
                             SoundManager.sendSound(player, "ChestReceive");
                         }
                         else {


### PR DESCRIPTION
1st PR:
Feature Suggestion:
- Possibility to enable / disable payment rounding
- Possibility to change the specific integers of said rounding
- Config options for both to allow the server owner the most flexibility
- Commented out a boolean that wasn't used in SellTask
- First attempt at trying to pre-index the common variables so they don't get setup each function call.

2nd PR:
Bug Fix:
- BuyChest message shows long float number instead of formatted 2 decimal rounded number. Dynamic configurable formatting for ChestShop is WIP.

3rd PR:
- Changed the WIP to implementation. Uses the same rounding logic as in SellTask and the same config options.